### PR TITLE
Removed an unnecessary entry in LSApplicationQueriesSchemes

### DIFF
--- a/LineSDKStarterObjC/LineSDKStarterObjC/Info.plist
+++ b/LineSDKStarterObjC/LineSDKStarterObjC/Info.plist
@@ -32,7 +32,6 @@
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>lineauth2</string>
-		<string>line3rdp.$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
`line3rdp.$(PRODUCT_BUNDLE_IDENTIFIER)` is not actually necessary in`LSApplicationQueriesSchemes` so I would like to remove it. 